### PR TITLE
fix: set amount step to 0.01 to allow floats

### DIFF
--- a/src/components/FormCreateExpense.tsx
+++ b/src/components/FormCreateExpense.tsx
@@ -70,6 +70,7 @@ export default function FormCreateExpense() {
           hideControls
           label="Amount"
           precision={2}
+          step="0.01"
           {...form.getInputProps("amount")}
         />
 

--- a/src/components/FormCreateIncome.tsx
+++ b/src/components/FormCreateIncome.tsx
@@ -70,6 +70,7 @@ export default function FormCreateIncome() {
           hideControls
           label="Amount"
           precision={2}
+          step="0.01"
           {...form.getInputProps("amount")}
         />
 

--- a/src/components/FormUpdateExpense.tsx
+++ b/src/components/FormUpdateExpense.tsx
@@ -93,6 +93,7 @@ export default function FormUpdateExpense({ expense }: Props) {
           hideControls
           label="Amount"
           precision={2}
+          step="0.01"
           {...form.getInputProps("amount")}
         />
 

--- a/src/components/FormUpdateIncome.tsx
+++ b/src/components/FormUpdateIncome.tsx
@@ -89,6 +89,7 @@ export default function FormUpdateIncome({ income }: Props) {
           hideControls
           label="Amount"
           precision={2}
+          step="0.01"
           {...form.getInputProps("amount")}
         />
 


### PR DESCRIPTION
Ce changement permettra d'entrer les cents sur iOS.

Avant:
![image](https://user-images.githubusercontent.com/2636763/202913148-b898d102-4899-4084-92fc-cab7bc857c8e.png)

Après:
<img width="695" alt="image" src="https://user-images.githubusercontent.com/2636763/202913158-2b5c5ef1-e044-4ecf-99dc-811d2ea90859.png">
